### PR TITLE
optimize active nodes connection

### DIFF
--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -126,7 +126,8 @@ public class ConnPoolService extends P2pEventHandler {
         addressInUse.add(address.getAddress());
         inetInUse.add(address);
         Node node = new Node(address); //use a random NodeId for config activeNodes
-        if (node.getPreferInetSocketAddress() != null) {
+        if (node.getPreferInetSocketAddress() != null
+            && peerClientCache.getIfPresent(node.getPreferInetSocketAddress()) == null) {
           connectNodes.add(node);
         }
       }
@@ -192,9 +193,9 @@ public class ConnPoolService extends P2pEventHandler {
     {
       connectNodes.forEach(n -> {
         log.info("Connect to peer {}", n.getPreferInetSocketAddress());
-        peerClient.connectAsync(n, false);
         peerClientCache.put(n.getPreferInetSocketAddress().getAddress(),
             System.currentTimeMillis());
+        peerClient.connectAsync(n, false);
         if (!configActiveNodes.contains(n.getPreferInetSocketAddress())) {
           connectingPeersCount.incrementAndGet();
         }
@@ -265,6 +266,8 @@ public class ConnPoolService extends P2pEventHandler {
 
   public void triggerConnect(InetSocketAddress address) {
     if (configActiveNodes.contains(address)) {
+      // delete address from peerClientCache
+      peerClientCache.invalidate(address.getAddress());
       return;
     }
     connectingPeersCount.decrementAndGet();


### PR DESCRIPTION
**What does this PR do?**
Do not repeatedly initiate connection requests when the handshake is incomplete during the active node connection.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**